### PR TITLE
Add command for numeric reply

### DIFF
--- a/lib/zircon.rb
+++ b/lib/zircon.rb
@@ -56,6 +56,7 @@ class Zircon
     WHO
     WHOIS
     WHOWAS
+    NUMERICREPLY
   ].freeze
 
   def initialize(args = {})

--- a/lib/zircon/callback.rb
+++ b/lib/zircon/callback.rb
@@ -7,7 +7,9 @@ class Zircon
     private
 
     def method_missing(method_name, *args, &block)
-      if method_name =~ /(list|on|trigger)_([a-z0-9]+)/
+      if method_name =~ /(list|on|trigger)_([0-9]+)/
+        send($1, 'numericreply', *args, &block)
+      elsif method_name =~ /(list|on|trigger)_([a-z0-9]+)/
         send($1, $2, *args, &block)
       else
         super

--- a/lib/zircon/callback.rb
+++ b/lib/zircon/callback.rb
@@ -7,9 +7,10 @@ class Zircon
     private
 
     def method_missing(method_name, *args, &block)
-      if method_name =~ /(list|on|trigger)_([0-9]+)/
+      case method_name
+      when /(list|on|trigger)_([0-9]+)/
         send($1, 'numericreply', *args, &block)
-      elsif method_name =~ /(list|on|trigger)_([a-z0-9]+)/
+      when /(list|on|trigger)_([a-z0-9]+)/
         send($1, $2, *args, &block)
       else
         super

--- a/spec/zircon_spec.rb
+++ b/spec/zircon_spec.rb
@@ -28,4 +28,29 @@ describe Zircon do
       Zircon.new.privmsg("channel", ":message")
     end
   end
+
+  describe "Callback for numeric reply" do
+    let(:callback) do
+      proc {|msg|}
+    end
+
+    let(:zircon) do
+      Zircon.new
+    end
+
+    before do
+      zircon.on_numericreply(&callback)
+    end
+
+    context "when triggered event name is number" do
+      let(:event) do
+        345
+      end
+
+      it "should be called" do
+        callback.should_receive(:call).with('message')
+        zircon.send("trigger_#{event}", 'message')
+      end
+    end
+  end
 end


### PR DESCRIPTION
cf. http://www.haun.org/kent/lib/rfc1459-irc-ja.html#c2.4
## Sample

``` ruby
require 'zircon'

client = Zircon.new(
  server: '127.0.01',
  port: 6667,
  channel: '#channel',
  username: 'dummy',
)

client.on_numericreply do |msg|
  puts "(#{msg.type}) #{msg.body}"
end

client.run!
```
## Output

```
(001) Welcome to the debian Internet Relay Chat Network dummy
(002) Your host is hybrid7.debian.local[127.0.0.1/6667], running version hybrid-7.2.2.dfsg.2-6
(003) This server was created Feb  8 2010 at 21:14:28
(004) hybrid7.debian.local
(005) CALLERID
(005) CHANLIMIT=#&:15
(251) There are 0 users and 3 invisible on 1 servers

...
```
