### PR TITLE
Check whether a value is nil that may be set nil in parsing IRC message'...

### DIFF
--- a/lib/zircon/message.rb
+++ b/lib/zircon/message.rb
@@ -40,7 +40,7 @@ class Zircon
         when !@rest[0].empty?
           middle, trailer, = *@rest
           params = middle.split(" ")
-        when !@rest[2].empty?
+        when !@rest[2].nil? && !@rest[2].empty?
           middle, trailer, = *@rest[2, 2]
           params = middle.split(" ")
         when @rest[1]

--- a/spec/zircon/message_spec.rb
+++ b/spec/zircon/message_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe Zircon::Message do
+  context 'when message is JOIN message' do
+    subject { described_class.new(":example!~example@example.com JOIN :#channel\r\n") }
+
+    describe "#to" do
+      its(:to) { should eq('#channel') }
+    end
+  end
+
+  context 'when message is PRIVMSG message' do
+    subject { described_class.new(":example!~example@www35420u.sakura.ne.jp PRIVMSG #channel :body\r\n") }
+
+    describe "#to" do
+      its(:to) { should eq('#channel') }
+    end
+
+    describe "#body" do
+      its(:body) { should eq('body') }
+    end
+  end
+end


### PR DESCRIPTION
``` ruby
join_msg = ":example!~example@example.com JOIN :#channel\r\n"
Zircon::Message::Patterns::MESSAGE_PATTERN.match(join_msg)[3..-1]
=> ["", "#channel", nil, nil]
```

Error will occur in lib/zircon/message.rb:43.

```
undefined method `empty?' for nil:NilClass (NoMethodError)
```

https://github.com/r7kamura/zircon/blob/master/lib/zircon/message.rb#L43

I don't understand perfectly Zircon::Message::Patterns::MESSAGE_PATTERN yet. (My knowledge of RegExp is a little...)
So I don't have self-confidence whether this approach is good...  
